### PR TITLE
Add deploy script, ignore temp deploy output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ app/out/
 
 # typescript
 **/*.tsbuildinfo
+
+# deploy output
+**/*.original

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,5 +1,5 @@
 [programs.localnet]
-bucket_program = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+bucket_program = "4c5Ef9CjxnXmkyc7WxQwNvA4wFWu7dw1sPCHoHxMh6CY"
 
 [registry]
 url = "https://anchor.projectserum.com"

--- a/app/src/utils/constant.ts
+++ b/app/src/utils/constant.ts
@@ -2,6 +2,6 @@ import { PublicKey } from "@solana/web3.js";
 
 import idl from "../types/bucket_program.json";
 
-export const BUCKET_PROGRAM_ID = new PublicKey("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+export const BUCKET_PROGRAM_ID = new PublicKey("4c5Ef9CjxnXmkyc7WxQwNvA4wFWu7dw1sPCHoHxMh6CY");
 
 export const BUCKET_PROGRAM_IDL = idl;

--- a/programs/bucket-program/src/context.rs
+++ b/programs/bucket-program/src/context.rs
@@ -22,6 +22,8 @@ use {
     },
 };
 
+/// if singleton (issue|withdraw) authority PDAs become problemtic,
+/// add additional seeds using either crate_token or crate_mint.
 #[derive(Accounts)]
 pub struct CreateBucket<'info> {
     /// Initializing payer is the default authority
@@ -104,7 +106,7 @@ pub struct Deposit<'info> {
 
     #[account(
         seeds = [
-            b"issue".as_ref()
+            b"issue".as_ref(),
         ],
         bump,
     )]

--- a/programs/bucket-program/src/lib.rs
+++ b/programs/bucket-program/src/lib.rs
@@ -7,7 +7,7 @@ mod state;
 
 use context::*;
 
-declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+declare_id!("4c5Ef9CjxnXmkyc7WxQwNvA4wFWu7dw1sPCHoHxMh6CY");
 
 #[program]
 pub mod bucket_program {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,51 @@
+if [ $# -gt 1 ]; then
+    echo "Cluster name is the only optional accepted parameter: devnet, mainnet-beta"
+    exit 1
+fi
+
+network='devnet' # set default if param not specified
+if [ $# -ne 0 ]; then
+    if [ "$1" = devnet ]; then
+        network='devnet'
+     elif [ "$1" = mainnet-beta ]; then
+        network='mainnet-beta'
+    else
+        echo "devnet, mainnet-beta are the only acceptable cluster names"
+        exit 1
+    fi
+fi
+
+echo "Deplying to $network";
+
+# fetch old pk
+old_bucket_pk=`solana-keygen pubkey ./target/deploy/bucket_program-keypair.json`
+echo Old public key: $old_bucket_pk
+
+# stash old keypair
+cd ./target/deploy # need to cd for renaming to work ok
+mv bucket_program-keypair.json bucket_program-keypair-`ls | wc -l | xargs`.json
+cd ./../..
+
+# build and fetch new pk
+anchor build
+new_bucket_pk=`solana-keygen pubkey ./target/deploy/bucket_program-keypair.json`
+echo New public key: $new_bucket_pk
+
+targets=$(find . -type f  -exec grep -lir --include=*.{ts,tsx,rs,toml} $old_bucket_pk {} +)
+for target in $targets
+do
+    sed -i'.original' -e "s/$old_bucket_pk/$new_bucket_pk/g" $target
+done
+echo Public key replaced!
+
+# build again with new pk
+anchor build
+
+# copy idl
+sh scripts/cp_idl.sh
+
+# deploy!
+solana balance # enough lamports left for deployment?
+anchor deploy --provider.cluster $network
+echo "DEPLOYED TO $network"
+solana balance

--- a/scripts/get_pk.sh
+++ b/scripts/get_pk.sh
@@ -1,0 +1,1 @@
+solana-keygen pubkey ./target/deploy/bucket_program-keypair.json


### PR DESCRIPTION
Add deploy script that abstracts away re-building and deploying. In the future, we might want to add some sort of flag that indicates if we should replace the program address — i.e. to indicate we only want to upgrade deployed program instead of deploying a fresh copy.