### PR TITLE
Add anchor constraint checks on ATAs in context objects

### DIFF
--- a/programs/bucket-program/src/context.rs
+++ b/programs/bucket-program/src/context.rs
@@ -122,16 +122,27 @@ pub struct Deposit<'info> {
     )]
     pub issue_authority: Box<Account<'info, IssueAuthority>>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = crate_collateral.mint == collateral_mint.key(),
+        constraint = crate_collateral.owner == common.crate_token.key()
+    )]
     pub crate_collateral: Box<Account<'info, TokenAccount>>,
 
-    // #[account(mut)]
     pub collateral_mint: Account<'info, Mint>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = depositor_collateral.mint == collateral_mint.key(),
+        constraint = depositor_collateral.owner == depositor.key()
+    )]
     pub depositor_collateral: Box<Account<'info, TokenAccount>>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = depositor_collateral.owner == depositor.key(),
+        constraint = depositor_reserve.mint == common.crate_mint.key(),
+    )]
     pub depositor_reserve: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: required for CPI into pyth
@@ -152,7 +163,11 @@ pub struct Redeem<'info> {
     )]
     pub withdraw_authority: Box<Account<'info, WithdrawAuthority>>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = withdrawer_reserve.owner == withdrawer.key(),
+        constraint = withdrawer_reserve.mint == common.crate_mint.key(),
+    )]
     pub withdrawer_reserve: Box<Account<'info, TokenAccount>>,
 
     /// CHECK: required for CPI into pyth
@@ -173,7 +188,11 @@ pub struct Common<'info> {
     /// CHECK: unsafe account type, required for CPI invocation.
     pub crate_token: UncheckedAccount<'info>,
 
-    #[account(mut)]
+    #[account(
+        mut,
+        constraint = crate_mint.freeze_authority.unwrap() == crate_token.key(),
+        constraint = crate_mint.mint_authority.unwrap() == crate_token.key(),
+    )]
     pub crate_mint: Account<'info, Mint>,
 
     pub crate_token_program: Program<'info, crate_token::program::CrateToken>,


### PR DESCRIPTION
Sanity constraint checks for account owners & mints. Tested with anchor test ✅