### PR TITLE
Add seed in issue and withdraw authority PDA derivation

### DIFF
--- a/programs/bucket-program/src/context.rs
+++ b/programs/bucket-program/src/context.rs
@@ -47,6 +47,7 @@ pub struct CreateBucket<'info> {
         init,
         seeds = [
             ISSUE_SEED.as_bytes(),
+            bucket.key().to_bytes().as_ref()
         ],
         bump,
         payer = payer
@@ -58,6 +59,7 @@ pub struct CreateBucket<'info> {
         init,
         seeds = [
             WITHDRAW_SEED.as_bytes(),
+            bucket.key().to_bytes().as_ref()
         ],
         bump,
         payer = payer
@@ -144,6 +146,7 @@ pub struct Rebalance<'info> {
     #[account(
         seeds = [
             WITHDRAW_SEED.as_bytes(),
+            bucket.key().to_bytes().as_ref()
         ],
         bump,
     )]
@@ -211,6 +214,7 @@ pub struct Deposit<'info> {
     #[account(
         seeds = [
             ISSUE_SEED.as_bytes(),
+            common.bucket.key().to_bytes().as_ref()
         ],
         bump,
     )]
@@ -252,6 +256,7 @@ pub struct Redeem<'info> {
     #[account(
         seeds = [
             WITHDRAW_SEED.as_bytes(),
+            common.bucket.key().to_bytes().as_ref()
         ],
         bump,
     )]

--- a/programs/bucket-program/src/instructions/deposit.rs
+++ b/programs/bucket-program/src/instructions/deposit.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        constant::TARGET_ORACLE_PRECISION,
+        constant::{ISSUE_SEED, TARGET_ORACLE_PRECISION},
         context::Deposit,
         error::ErrorCode,
         state::oracle::{get_oracle_price, OraclePriceData},
@@ -41,10 +41,17 @@ pub fn handle(ctx: Context<Deposit>, deposit_amount: u64) -> ProgramResult {
         .unwrap()
         .checked_div(10_i128.pow(TARGET_ORACLE_PRECISION))
         .unwrap();
+
+    let bucket = ctx.accounts.common.bucket.key();
+    let issue_authority_signer_seeds: &[&[&[u8]]] = &[&[
+        ISSUE_SEED.as_bytes(),
+        bucket.as_ref(),
+        &[ctx.accounts.issue_authority.bump],
+    ]];
     issue(
         ctx.accounts
             .into_issue_reserve_context()
-            .with_signer(&[&[b"issue", &[ctx.accounts.issue_authority.bump]]]),
+            .with_signer(issue_authority_signer_seeds),
         issue_amount.try_into().unwrap(),
     )?;
 

--- a/programs/bucket-program/src/instructions/rebalance.rs
+++ b/programs/bucket-program/src/instructions/rebalance.rs
@@ -49,13 +49,16 @@ pub fn handle<'info>(
         minimum_amount_out,
     )?;
 
+    let bucket = ctx.accounts.bucket.key();
+    let withdraw_authority_signer_seeds: &[&[&[u8]]] = &[&[
+        WITHDRAW_SEED.as_bytes(),
+        bucket.as_ref(),
+        &[ctx.accounts.withdraw_authority.bump],
+    ]];
     withdraw(
         ctx.accounts
             .into_withdraw_collateral_context(&rebalance_asset)
-            .with_signer(&[&[
-                WITHDRAW_SEED.as_bytes(),
-                &[ctx.accounts.withdraw_authority.bump],
-            ]]),
+            .with_signer(withdraw_authority_signer_seeds),
         swap_amounts.amount_in,
     )?;
 

--- a/programs/bucket-program/src/instructions/redeem.rs
+++ b/programs/bucket-program/src/instructions/redeem.rs
@@ -37,9 +37,12 @@ pub fn handle<'info>(
     if num_remaining_accounts == 0 {
         return Ok(());
     }
+
     let remaining_accounts_iter = &mut ctx.remaining_accounts.iter();
+    let bucket = ctx.accounts.common.bucket.key();
     let withdraw_authority_signer_seeds: &[&[&[u8]]] = &[&[
         WITHDRAW_SEED.as_bytes(),
+        bucket.as_ref(),
         &[ctx.accounts.withdraw_authority.bump],
     ]];
 

--- a/sdk/src/bucket.ts
+++ b/sdk/src/bucket.ts
@@ -110,9 +110,10 @@ export class BucketClient extends AccountUtils {
   };
 
   generateIssueAuthority = async (
+    bucket: PublicKey,
     programID: PublicKey = this.bucketProgram.programId
   ) => {
-    const [addr, bump] = await this.findProgramAddress(programID, ["issue"]);
+    const [addr, bump] = await this.findProgramAddress(programID, ["issue", bucket]);
 
     return {
       addr,
@@ -121,9 +122,10 @@ export class BucketClient extends AccountUtils {
   };
 
   generateWithdrawAuthority = async (
+    bucket: PublicKey,
     programID: PublicKey = this.bucketProgram.programId
   ) => {
-    const [addr, bump] = await this.findProgramAddress(programID, ["withdraw"]);
+    const [addr, bump] = await this.findProgramAddress(programID, ["withdraw", bucket]);
 
     return {
       addr,
@@ -284,9 +286,9 @@ export class BucketClient extends AccountUtils {
       crate
     );
     const { addr: issueAuthority, bump: issueBump } =
-      await this.generateIssueAuthority();
+      await this.generateIssueAuthority(bucket);
     const { addr: withdrawAuthority, bump: withdrawBump } =
-      await this.generateWithdrawAuthority();
+      await this.generateWithdrawAuthority(bucket);
 
     const signerInfo = getSignersFromPayer(payer);
     const crateATA = await this.getOrCreateATA(
@@ -602,7 +604,7 @@ export class BucketClient extends AccountUtils {
           payer: signerInfo.payer,
           bucket,
           crateToken: crate,
-          withdrawAuthority: (await this.generateWithdrawAuthority()).addr,
+          withdrawAuthority: (await this.generateWithdrawAuthority(bucket)).addr,
           swap: fetchedStableSwap.config.swapAccount,
           swapAuthority: fetchedStableSwap.config.authority,
           userAuthority: signerInfo.payer,

--- a/sdk/src/types/bucket_program.ts
+++ b/sdk/src/types/bucket_program.ts
@@ -490,6 +490,53 @@ export type BucketProgram = {
       }
     },
     {
+      "name": "ErrorCode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "WrongBurnError"
+          },
+          {
+            "name": "AllocationBpsError"
+          },
+          {
+            "name": "WrongCollateralError"
+          },
+          {
+            "name": "CollateralAlreadyAuthorizedError"
+          },
+          {
+            "name": "CollateralDoesNotExistError"
+          },
+          {
+            "name": "CollateralSizeLimitsExceeded"
+          },
+          {
+            "name": "CallerCannotRebalanceCollateral"
+          },
+          {
+            "name": "MinCollateralError"
+          },
+          {
+            "name": "NumberOfSizeNotSupported"
+          },
+          {
+            "name": "UnableToLoadOracle"
+          },
+          {
+            "name": "MathError"
+          },
+          {
+            "name": "CastingFailure"
+          },
+          {
+            "name": "InvalidOracle"
+          }
+        ]
+      }
+    },
+    {
       "name": "OracleSource",
       "type": {
         "kind": "enum",
@@ -553,73 +600,6 @@ export type BucketProgram = {
           }
         ]
       }
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "WrongBurnError",
-      "msg": "Must burn reserve token"
-    },
-    {
-      "code": 6001,
-      "name": "AllocationBpsError",
-      "msg": "Allocation bps error"
-    },
-    {
-      "code": 6002,
-      "name": "WrongCollateralError",
-      "msg": "Must deposit an approved collateral mint"
-    },
-    {
-      "code": 6003,
-      "name": "CollateralAlreadyAuthorizedError",
-      "msg": "Cannot re-authorized a collateral mint authorized"
-    },
-    {
-      "code": 6004,
-      "name": "CollateralDoesNotExistError",
-      "msg": "Cannot de-authorized a collateral mint that does not exist"
-    },
-    {
-      "code": 6005,
-      "name": "CollateralSizeLimitsExceeded",
-      "msg": "Collateral size limits exceeded"
-    },
-    {
-      "code": 6006,
-      "name": "CallerCannotRebalanceCollateral",
-      "msg": "Caller is not authorized to rebalance specified mints"
-    },
-    {
-      "code": 6007,
-      "name": "MinCollateralError",
-      "msg": "Must maintain at least 1 approved collateral mint"
-    },
-    {
-      "code": 6008,
-      "name": "NumberOfSizeNotSupported",
-      "msg": "Number is too large and is not supported"
-    },
-    {
-      "code": 6009,
-      "name": "UnableToLoadOracle",
-      "msg": "Unable To Load Oracles"
-    },
-    {
-      "code": 6010,
-      "name": "MathError",
-      "msg": "Math Error"
-    },
-    {
-      "code": 6011,
-      "name": "CastingFailure",
-      "msg": "Casting Failure"
-    },
-    {
-      "code": 6012,
-      "name": "InvalidOracle",
-      "msg": "Oracle Values are invalid"
     }
   ]
 };
@@ -1116,6 +1096,53 @@ export const IDL: BucketProgram = {
       }
     },
     {
+      "name": "ErrorCode",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "WrongBurnError"
+          },
+          {
+            "name": "AllocationBpsError"
+          },
+          {
+            "name": "WrongCollateralError"
+          },
+          {
+            "name": "CollateralAlreadyAuthorizedError"
+          },
+          {
+            "name": "CollateralDoesNotExistError"
+          },
+          {
+            "name": "CollateralSizeLimitsExceeded"
+          },
+          {
+            "name": "CallerCannotRebalanceCollateral"
+          },
+          {
+            "name": "MinCollateralError"
+          },
+          {
+            "name": "NumberOfSizeNotSupported"
+          },
+          {
+            "name": "UnableToLoadOracle"
+          },
+          {
+            "name": "MathError"
+          },
+          {
+            "name": "CastingFailure"
+          },
+          {
+            "name": "InvalidOracle"
+          }
+        ]
+      }
+    },
+    {
       "name": "OracleSource",
       "type": {
         "kind": "enum",
@@ -1179,73 +1206,6 @@ export const IDL: BucketProgram = {
           }
         ]
       }
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "WrongBurnError",
-      "msg": "Must burn reserve token"
-    },
-    {
-      "code": 6001,
-      "name": "AllocationBpsError",
-      "msg": "Allocation bps error"
-    },
-    {
-      "code": 6002,
-      "name": "WrongCollateralError",
-      "msg": "Must deposit an approved collateral mint"
-    },
-    {
-      "code": 6003,
-      "name": "CollateralAlreadyAuthorizedError",
-      "msg": "Cannot re-authorized a collateral mint authorized"
-    },
-    {
-      "code": 6004,
-      "name": "CollateralDoesNotExistError",
-      "msg": "Cannot de-authorized a collateral mint that does not exist"
-    },
-    {
-      "code": 6005,
-      "name": "CollateralSizeLimitsExceeded",
-      "msg": "Collateral size limits exceeded"
-    },
-    {
-      "code": 6006,
-      "name": "CallerCannotRebalanceCollateral",
-      "msg": "Caller is not authorized to rebalance specified mints"
-    },
-    {
-      "code": 6007,
-      "name": "MinCollateralError",
-      "msg": "Must maintain at least 1 approved collateral mint"
-    },
-    {
-      "code": 6008,
-      "name": "NumberOfSizeNotSupported",
-      "msg": "Number is too large and is not supported"
-    },
-    {
-      "code": 6009,
-      "name": "UnableToLoadOracle",
-      "msg": "Unable To Load Oracles"
-    },
-    {
-      "code": 6010,
-      "name": "MathError",
-      "msg": "Math Error"
-    },
-    {
-      "code": 6011,
-      "name": "CastingFailure",
-      "msg": "Casting Failure"
-    },
-    {
-      "code": 6012,
-      "name": "InvalidOracle",
-      "msg": "Oracle Values are invalid"
     }
   ]
 };


### PR DESCRIPTION
previously, we could only create 1 instance of issue/withdraw since they were initialized with a single, static string. adding the bucket key will allow us to create multiple buckets per deployed program. more flexibility in ops, testing, etc.