### PR TITLE
cap exchange rate to 1 in deposit instruction

### DIFF
--- a/sdk/src/types/bucket_program.ts
+++ b/sdk/src/types/bucket_program.ts
@@ -490,53 +490,6 @@ export type BucketProgram = {
       }
     },
     {
-      "name": "ErrorCode",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "WrongBurnError"
-          },
-          {
-            "name": "AllocationBpsError"
-          },
-          {
-            "name": "WrongCollateralError"
-          },
-          {
-            "name": "CollateralAlreadyAuthorizedError"
-          },
-          {
-            "name": "CollateralDoesNotExistError"
-          },
-          {
-            "name": "CollateralSizeLimitsExceeded"
-          },
-          {
-            "name": "CallerCannotRebalanceCollateral"
-          },
-          {
-            "name": "MinCollateralError"
-          },
-          {
-            "name": "NumberOfSizeNotSupported"
-          },
-          {
-            "name": "UnableToLoadOracle"
-          },
-          {
-            "name": "MathError"
-          },
-          {
-            "name": "CastingFailure"
-          },
-          {
-            "name": "InvalidOracle"
-          }
-        ]
-      }
-    },
-    {
       "name": "OracleSource",
       "type": {
         "kind": "enum",
@@ -600,6 +553,73 @@ export type BucketProgram = {
           }
         ]
       }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "WrongBurnError",
+      "msg": "Must burn reserve token"
+    },
+    {
+      "code": 6001,
+      "name": "AllocationBpsError",
+      "msg": "Allocation bps error"
+    },
+    {
+      "code": 6002,
+      "name": "WrongCollateralError",
+      "msg": "Must deposit an approved collateral mint"
+    },
+    {
+      "code": 6003,
+      "name": "CollateralAlreadyAuthorizedError",
+      "msg": "Cannot re-authorized a collateral mint authorized"
+    },
+    {
+      "code": 6004,
+      "name": "CollateralDoesNotExistError",
+      "msg": "Cannot de-authorized a collateral mint that does not exist"
+    },
+    {
+      "code": 6005,
+      "name": "CollateralSizeLimitsExceeded",
+      "msg": "Collateral size limits exceeded"
+    },
+    {
+      "code": 6006,
+      "name": "CallerCannotRebalanceCollateral",
+      "msg": "Caller is not authorized to rebalance specified mints"
+    },
+    {
+      "code": 6007,
+      "name": "MinCollateralError",
+      "msg": "Must maintain at least 1 approved collateral mint"
+    },
+    {
+      "code": 6008,
+      "name": "NumberOfSizeNotSupported",
+      "msg": "Number is too large and is not supported"
+    },
+    {
+      "code": 6009,
+      "name": "UnableToLoadOracle",
+      "msg": "Unable To Load Oracles"
+    },
+    {
+      "code": 6010,
+      "name": "MathError",
+      "msg": "Math Error"
+    },
+    {
+      "code": 6011,
+      "name": "CastingFailure",
+      "msg": "Casting Failure"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidOracle",
+      "msg": "Oracle Values are invalid"
     }
   ]
 };
@@ -1096,53 +1116,6 @@ export const IDL: BucketProgram = {
       }
     },
     {
-      "name": "ErrorCode",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "WrongBurnError"
-          },
-          {
-            "name": "AllocationBpsError"
-          },
-          {
-            "name": "WrongCollateralError"
-          },
-          {
-            "name": "CollateralAlreadyAuthorizedError"
-          },
-          {
-            "name": "CollateralDoesNotExistError"
-          },
-          {
-            "name": "CollateralSizeLimitsExceeded"
-          },
-          {
-            "name": "CallerCannotRebalanceCollateral"
-          },
-          {
-            "name": "MinCollateralError"
-          },
-          {
-            "name": "NumberOfSizeNotSupported"
-          },
-          {
-            "name": "UnableToLoadOracle"
-          },
-          {
-            "name": "MathError"
-          },
-          {
-            "name": "CastingFailure"
-          },
-          {
-            "name": "InvalidOracle"
-          }
-        ]
-      }
-    },
-    {
       "name": "OracleSource",
       "type": {
         "kind": "enum",
@@ -1206,6 +1179,73 @@ export const IDL: BucketProgram = {
           }
         ]
       }
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "WrongBurnError",
+      "msg": "Must burn reserve token"
+    },
+    {
+      "code": 6001,
+      "name": "AllocationBpsError",
+      "msg": "Allocation bps error"
+    },
+    {
+      "code": 6002,
+      "name": "WrongCollateralError",
+      "msg": "Must deposit an approved collateral mint"
+    },
+    {
+      "code": 6003,
+      "name": "CollateralAlreadyAuthorizedError",
+      "msg": "Cannot re-authorized a collateral mint authorized"
+    },
+    {
+      "code": 6004,
+      "name": "CollateralDoesNotExistError",
+      "msg": "Cannot de-authorized a collateral mint that does not exist"
+    },
+    {
+      "code": 6005,
+      "name": "CollateralSizeLimitsExceeded",
+      "msg": "Collateral size limits exceeded"
+    },
+    {
+      "code": 6006,
+      "name": "CallerCannotRebalanceCollateral",
+      "msg": "Caller is not authorized to rebalance specified mints"
+    },
+    {
+      "code": 6007,
+      "name": "MinCollateralError",
+      "msg": "Must maintain at least 1 approved collateral mint"
+    },
+    {
+      "code": 6008,
+      "name": "NumberOfSizeNotSupported",
+      "msg": "Number is too large and is not supported"
+    },
+    {
+      "code": 6009,
+      "name": "UnableToLoadOracle",
+      "msg": "Unable To Load Oracles"
+    },
+    {
+      "code": 6010,
+      "name": "MathError",
+      "msg": "Math Error"
+    },
+    {
+      "code": 6011,
+      "name": "CastingFailure",
+      "msg": "Casting Failure"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidOracle",
+      "msg": "Oracle Values are invalid"
     }
   ]
 };


### PR DESCRIPTION
As discussed offline, this prevents oracle attacks on the deposit instruction that try to manipulate prices such that a USD-pegged stablecoin trades or is quoted at higher than 1 USD.